### PR TITLE
spike/missing-props

### DIFF
--- a/src/contentContainer/__snapshots__/ContentContainer.test.js.snap
+++ b/src/contentContainer/__snapshots__/ContentContainer.test.js.snap
@@ -245,6 +245,240 @@ exports[`ContentContainer should render as snapshot defines 1`] = `
   >
     <div
       className="app-0-0"
+      sheet={
+        StyleSheet {
+          "0.42": null,
+          "attached": true,
+          "classes": Object {
+            "app": "app-0-0",
+          },
+          "deployed": true,
+          "linked": false,
+          "options": Object {
+            "Renderer": [Function],
+            "classes": Object {
+              "app": "app-0-0",
+            },
+            "generateClassName": [Function],
+            "index": -100000,
+            "insertionPoint": undefined,
+            "jss": Jss {
+              "generateClassName": [Function],
+              "options": Object {
+                "Renderer": [Function],
+                "createGenerateClassName": [Function],
+                "plugins": Array [
+                  Object {
+                    "onCreateRule": [Function],
+                    "onProcessRule": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onChangeValue": [Function],
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onChangeValue": [Function],
+                    "onProcessRule": [Function],
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                ],
+              },
+              "plugins": PluginsRegistry {
+                "hooks": Object {
+                  "onChangeValue": Array [
+                    [Function],
+                    [Function],
+                  ],
+                  "onCreateRule": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                  "onProcessRule": Array [
+                    [Function],
+                    [Function],
+                  ],
+                  "onProcessSheet": Array [],
+                  "onProcessStyle": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+              },
+              "version": "8.1.0",
+            },
+            "meta": "Jss(_ContentContainer), Unthemed, Static",
+            "parent": [Circular],
+            "sheet": [Circular],
+          },
+          "renderer": DomRenderer {
+            "element": <style
+              data-jss=""
+              data-meta="Jss(_ContentContainer), Unthemed, Static"
+              type="text/css"
+            >
+              
+.app-0-0 {
+  margin: auto;
+  max-width: 1200px;
+}
+
+            </style>,
+            "getSelector": [Function],
+            "getStyle": [Function],
+            "hasInsertedRules": false,
+            "setSelector": [Function],
+            "setStyle": [Function],
+            "sheet": [Circular],
+          },
+          "rules": RuleList {
+            "classes": Object {
+              "app": "app-0-0",
+            },
+            "index": Array [
+              Object {
+                "margin": "auto",
+                "max-width": "1200px",
+              },
+            ],
+            "map": Object {
+              ".app-0-0": Object {
+                "margin": "auto",
+                "max-width": "1200px",
+              },
+              "app": Object {
+                "margin": "auto",
+                "max-width": "1200px",
+              },
+            },
+            "options": Object {
+              "Renderer": [Function],
+              "classes": Object {
+                "app": "app-0-0",
+              },
+              "generateClassName": [Function],
+              "index": -100000,
+              "insertionPoint": undefined,
+              "jss": Jss {
+                "generateClassName": [Function],
+                "options": Object {
+                  "Renderer": [Function],
+                  "createGenerateClassName": [Function],
+                  "plugins": Array [
+                    Object {
+                      "onCreateRule": [Function],
+                      "onProcessRule": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onChangeValue": [Function],
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onChangeValue": [Function],
+                      "onProcessRule": [Function],
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                  ],
+                },
+                "plugins": PluginsRegistry {
+                  "hooks": Object {
+                    "onChangeValue": Array [
+                      [Function],
+                      [Function],
+                    ],
+                    "onCreateRule": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                    "onProcessRule": Array [
+                      [Function],
+                      [Function],
+                    ],
+                    "onProcessSheet": Array [],
+                    "onProcessStyle": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                },
+                "version": "8.1.0",
+              },
+              "meta": "Jss(_ContentContainer), Unthemed, Static",
+              "parent": [Circular],
+              "sheet": [Circular],
+            },
+            "raw": Object {
+              "app": Object {
+                "margin": "auto",
+                "maxWidth": "1200px",
+              },
+            },
+          },
+        }
+      }
     />
   </_ContentContainer>
 </Jss(_ContentContainer)>

--- a/src/contentContainer/index.js
+++ b/src/contentContainer/index.js
@@ -19,7 +19,7 @@ function _ContentContainer (props) {
   } = props;
 
   return (
-    <div className={classNames(classes.app, className)}>
+    <div {...remainingProps} className={classNames(classes.app, className)}>
       {children}
     </div>
   );

--- a/src/placeholder/__snapshots__/Placeholder.test.js.snap
+++ b/src/placeholder/__snapshots__/Placeholder.test.js.snap
@@ -821,7 +821,811 @@ exports[`Placeholder should render as snapshot defines 1`] = `
   >
     <div
       className="shimmer-0-0"
-      style={undefined}
+      sheet={
+        StyleSheet {
+          "0.42": null,
+          "attached": true,
+          "classes": Object {
+            "0%": "%",
+            "100%": "00%",
+            "35%": "5%",
+            "50%": "0%",
+            "65%": "5%",
+            "shimmer": "shimmer-0-0",
+          },
+          "deployed": true,
+          "linked": false,
+          "options": Object {
+            "Renderer": [Function],
+            "classes": Object {
+              "0%": "%",
+              "100%": "00%",
+              "35%": "5%",
+              "50%": "0%",
+              "65%": "5%",
+              "shimmer": "shimmer-0-0",
+            },
+            "generateClassName": [Function],
+            "index": -100000,
+            "insertionPoint": undefined,
+            "jss": Jss {
+              "generateClassName": [Function],
+              "options": Object {
+                "Renderer": [Function],
+                "createGenerateClassName": [Function],
+                "plugins": Array [
+                  Object {
+                    "onCreateRule": [Function],
+                    "onProcessRule": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onChangeValue": [Function],
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onChangeValue": [Function],
+                    "onProcessRule": [Function],
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                ],
+              },
+              "plugins": PluginsRegistry {
+                "hooks": Object {
+                  "onChangeValue": Array [
+                    [Function],
+                    [Function],
+                  ],
+                  "onCreateRule": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                  "onProcessRule": Array [
+                    [Function],
+                    [Function],
+                  ],
+                  "onProcessSheet": Array [],
+                  "onProcessStyle": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+              },
+              "version": "8.1.0",
+            },
+            "meta": "Jss(_Placeholder), Unthemed, Static",
+            "parent": [Circular],
+            "sheet": [Circular],
+          },
+          "renderer": DomRenderer {
+            "element": <style
+              data-jss=""
+              data-meta="Jss(_Placeholder), Unthemed, Static"
+              type="text/css"
+            >
+              
+@keyframes placeHolderShimmer {
+  0% {
+    background-color: #dddddd;
+  }
+  35% {
+    background-color: #dddddd;
+  }
+  50% {
+    background-color: #eeeeee;
+  }
+  65% {
+    background-color: #dddddd;
+  }
+  100% {
+    background-color: #dddddd;
+  }
+}
+.shimmer-0-0 {
+  color: rgba(0,0,0,0);
+  border-radius: 4px;
+  animation-name: placeHolderShimmer;
+  text-decoration: none;
+  animation-duration: 1.5s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+}
+
+            </style>,
+            "getSelector": [Function],
+            "getStyle": [Function],
+            "hasInsertedRules": false,
+            "setSelector": [Function],
+            "setStyle": [Function],
+            "sheet": [Circular],
+          },
+          "rules": RuleList {
+            "classes": Object {
+              "0%": "%",
+              "100%": "00%",
+              "35%": "5%",
+              "50%": "0%",
+              "65%": "5%",
+              "shimmer": "shimmer-0-0",
+            },
+            "index": Array [
+              KeyframesRule {
+                "isProcessed": true,
+                "key": "@keyframes placeHolderShimmer",
+                "options": Object {
+                  "Renderer": [Function],
+                  "classes": Object {
+                    "0%": "%",
+                    "100%": "00%",
+                    "35%": "5%",
+                    "50%": "0%",
+                    "65%": "5%",
+                    "shimmer": "shimmer-0-0",
+                  },
+                  "generateClassName": [Function],
+                  "jss": Jss {
+                    "generateClassName": [Function],
+                    "options": Object {
+                      "Renderer": [Function],
+                      "createGenerateClassName": [Function],
+                      "plugins": Array [
+                        Object {
+                          "onCreateRule": [Function],
+                          "onProcessRule": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onChangeValue": [Function],
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onChangeValue": [Function],
+                          "onProcessRule": [Function],
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                      ],
+                    },
+                    "plugins": PluginsRegistry {
+                      "hooks": Object {
+                        "onChangeValue": Array [
+                          [Function],
+                          [Function],
+                        ],
+                        "onCreateRule": Array [
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                        ],
+                        "onProcessRule": Array [
+                          [Function],
+                          [Function],
+                        ],
+                        "onProcessSheet": Array [],
+                        "onProcessStyle": Array [
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                        ],
+                      },
+                    },
+                    "version": "8.1.0",
+                  },
+                  "parent": [Circular],
+                  "sheet": [Circular],
+                },
+                "rules": RuleList {
+                  "classes": Object {
+                    "0%": "%",
+                    "100%": "00%",
+                    "35%": "5%",
+                    "50%": "0%",
+                    "65%": "5%",
+                    "shimmer": "shimmer-0-0",
+                  },
+                  "index": Array [
+                    Object {
+                      "background-color": "#dddddd",
+                    },
+                    Object {
+                      "background-color": "#dddddd",
+                    },
+                    Object {
+                      "background-color": "#eeeeee",
+                    },
+                    Object {
+                      "background-color": "#dddddd",
+                    },
+                    Object {
+                      "background-color": "#dddddd",
+                    },
+                  ],
+                  "map": Object {
+                    "0%": Object {
+                      "background-color": "#dddddd",
+                    },
+                    "100%": Object {
+                      "background-color": "#dddddd",
+                    },
+                    "35%": Object {
+                      "background-color": "#dddddd",
+                    },
+                    "50%": Object {
+                      "background-color": "#eeeeee",
+                    },
+                    "65%": Object {
+                      "background-color": "#dddddd",
+                    },
+                  },
+                  "options": Object {
+                    "Renderer": [Function],
+                    "classes": Object {
+                      "0%": "%",
+                      "100%": "00%",
+                      "35%": "5%",
+                      "50%": "0%",
+                      "65%": "5%",
+                      "shimmer": "shimmer-0-0",
+                    },
+                    "generateClassName": [Function],
+                    "jss": Jss {
+                      "generateClassName": [Function],
+                      "options": Object {
+                        "Renderer": [Function],
+                        "createGenerateClassName": [Function],
+                        "plugins": Array [
+                          Object {
+                            "onCreateRule": [Function],
+                            "onProcessRule": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onChangeValue": [Function],
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onChangeValue": [Function],
+                            "onProcessRule": [Function],
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                        ],
+                      },
+                      "plugins": PluginsRegistry {
+                        "hooks": Object {
+                          "onChangeValue": Array [
+                            [Function],
+                            [Function],
+                          ],
+                          "onCreateRule": Array [
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                          ],
+                          "onProcessRule": Array [
+                            [Function],
+                            [Function],
+                          ],
+                          "onProcessSheet": Array [],
+                          "onProcessStyle": Array [
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                          ],
+                        },
+                      },
+                      "version": "8.1.0",
+                    },
+                    "parent": [Circular],
+                    "sheet": [Circular],
+                  },
+                  "raw": Object {
+                    "0%": Object {
+                      "backgroundColor": "#dddddd",
+                    },
+                    "100%": Object {
+                      "backgroundColor": "#dddddd",
+                    },
+                    "35%": Object {
+                      "backgroundColor": "#dddddd",
+                    },
+                    "50%": Object {
+                      "backgroundColor": "#eeeeee",
+                    },
+                    "65%": Object {
+                      "backgroundColor": "#dddddd",
+                    },
+                  },
+                },
+                "type": "keyframes",
+              },
+              Object {
+                "animation-duration": "1.5s",
+                "animation-iteration-count": "infinite",
+                "animation-name": "placeHolderShimmer",
+                "animation-timing-function": "linear",
+                "border-radius": "4px",
+                "color": "rgba(0,0,0,0)",
+                "text-decoration": "none",
+              },
+            ],
+            "map": Object {
+              ".shimmer-0-0": Object {
+                "animation-duration": "1.5s",
+                "animation-iteration-count": "infinite",
+                "animation-name": "placeHolderShimmer",
+                "animation-timing-function": "linear",
+                "border-radius": "4px",
+                "color": "rgba(0,0,0,0)",
+                "text-decoration": "none",
+              },
+              "@keyframes placeHolderShimmer": KeyframesRule {
+                "isProcessed": true,
+                "key": "@keyframes placeHolderShimmer",
+                "options": Object {
+                  "Renderer": [Function],
+                  "classes": Object {
+                    "0%": "%",
+                    "100%": "00%",
+                    "35%": "5%",
+                    "50%": "0%",
+                    "65%": "5%",
+                    "shimmer": "shimmer-0-0",
+                  },
+                  "generateClassName": [Function],
+                  "jss": Jss {
+                    "generateClassName": [Function],
+                    "options": Object {
+                      "Renderer": [Function],
+                      "createGenerateClassName": [Function],
+                      "plugins": Array [
+                        Object {
+                          "onCreateRule": [Function],
+                          "onProcessRule": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onChangeValue": [Function],
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onChangeValue": [Function],
+                          "onProcessRule": [Function],
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                      ],
+                    },
+                    "plugins": PluginsRegistry {
+                      "hooks": Object {
+                        "onChangeValue": Array [
+                          [Function],
+                          [Function],
+                        ],
+                        "onCreateRule": Array [
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                        ],
+                        "onProcessRule": Array [
+                          [Function],
+                          [Function],
+                        ],
+                        "onProcessSheet": Array [],
+                        "onProcessStyle": Array [
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                        ],
+                      },
+                    },
+                    "version": "8.1.0",
+                  },
+                  "parent": [Circular],
+                  "sheet": [Circular],
+                },
+                "rules": RuleList {
+                  "classes": Object {
+                    "0%": "%",
+                    "100%": "00%",
+                    "35%": "5%",
+                    "50%": "0%",
+                    "65%": "5%",
+                    "shimmer": "shimmer-0-0",
+                  },
+                  "index": Array [
+                    Object {
+                      "background-color": "#dddddd",
+                    },
+                    Object {
+                      "background-color": "#dddddd",
+                    },
+                    Object {
+                      "background-color": "#eeeeee",
+                    },
+                    Object {
+                      "background-color": "#dddddd",
+                    },
+                    Object {
+                      "background-color": "#dddddd",
+                    },
+                  ],
+                  "map": Object {
+                    "0%": Object {
+                      "background-color": "#dddddd",
+                    },
+                    "100%": Object {
+                      "background-color": "#dddddd",
+                    },
+                    "35%": Object {
+                      "background-color": "#dddddd",
+                    },
+                    "50%": Object {
+                      "background-color": "#eeeeee",
+                    },
+                    "65%": Object {
+                      "background-color": "#dddddd",
+                    },
+                  },
+                  "options": Object {
+                    "Renderer": [Function],
+                    "classes": Object {
+                      "0%": "%",
+                      "100%": "00%",
+                      "35%": "5%",
+                      "50%": "0%",
+                      "65%": "5%",
+                      "shimmer": "shimmer-0-0",
+                    },
+                    "generateClassName": [Function],
+                    "jss": Jss {
+                      "generateClassName": [Function],
+                      "options": Object {
+                        "Renderer": [Function],
+                        "createGenerateClassName": [Function],
+                        "plugins": Array [
+                          Object {
+                            "onCreateRule": [Function],
+                            "onProcessRule": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onChangeValue": [Function],
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onChangeValue": [Function],
+                            "onProcessRule": [Function],
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                        ],
+                      },
+                      "plugins": PluginsRegistry {
+                        "hooks": Object {
+                          "onChangeValue": Array [
+                            [Function],
+                            [Function],
+                          ],
+                          "onCreateRule": Array [
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                          ],
+                          "onProcessRule": Array [
+                            [Function],
+                            [Function],
+                          ],
+                          "onProcessSheet": Array [],
+                          "onProcessStyle": Array [
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                          ],
+                        },
+                      },
+                      "version": "8.1.0",
+                    },
+                    "parent": [Circular],
+                    "sheet": [Circular],
+                  },
+                  "raw": Object {
+                    "0%": Object {
+                      "backgroundColor": "#dddddd",
+                    },
+                    "100%": Object {
+                      "backgroundColor": "#dddddd",
+                    },
+                    "35%": Object {
+                      "backgroundColor": "#dddddd",
+                    },
+                    "50%": Object {
+                      "backgroundColor": "#eeeeee",
+                    },
+                    "65%": Object {
+                      "backgroundColor": "#dddddd",
+                    },
+                  },
+                },
+                "type": "keyframes",
+              },
+              "shimmer": Object {
+                "animation-duration": "1.5s",
+                "animation-iteration-count": "infinite",
+                "animation-name": "placeHolderShimmer",
+                "animation-timing-function": "linear",
+                "border-radius": "4px",
+                "color": "rgba(0,0,0,0)",
+                "text-decoration": "none",
+              },
+            },
+            "options": Object {
+              "Renderer": [Function],
+              "classes": Object {
+                "0%": "%",
+                "100%": "00%",
+                "35%": "5%",
+                "50%": "0%",
+                "65%": "5%",
+                "shimmer": "shimmer-0-0",
+              },
+              "generateClassName": [Function],
+              "index": -100000,
+              "insertionPoint": undefined,
+              "jss": Jss {
+                "generateClassName": [Function],
+                "options": Object {
+                  "Renderer": [Function],
+                  "createGenerateClassName": [Function],
+                  "plugins": Array [
+                    Object {
+                      "onCreateRule": [Function],
+                      "onProcessRule": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onChangeValue": [Function],
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onChangeValue": [Function],
+                      "onProcessRule": [Function],
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                  ],
+                },
+                "plugins": PluginsRegistry {
+                  "hooks": Object {
+                    "onChangeValue": Array [
+                      [Function],
+                      [Function],
+                    ],
+                    "onCreateRule": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                    "onProcessRule": Array [
+                      [Function],
+                      [Function],
+                    ],
+                    "onProcessSheet": Array [],
+                    "onProcessStyle": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                },
+                "version": "8.1.0",
+              },
+              "meta": "Jss(_Placeholder), Unthemed, Static",
+              "parent": [Circular],
+              "sheet": [Circular],
+            },
+            "raw": Object {
+              "@keyframes placeHolderShimmer": Object {
+                "0%": Object {
+                  "backgroundColor": "#dddddd",
+                },
+                "100%": Object {
+                  "backgroundColor": "#dddddd",
+                },
+                "35%": Object {
+                  "backgroundColor": "#dddddd",
+                },
+                "50%": Object {
+                  "backgroundColor": "#eeeeee",
+                },
+                "65%": Object {
+                  "backgroundColor": "#dddddd",
+                },
+              },
+              "shimmer": Object {
+                "animationDuration": "1.5s",
+                "animationIterationCount": "infinite",
+                "animationName": "placeHolderShimmer",
+                "animationTimingFunction": "linear",
+                "borderRadius": "4px",
+                "color": "rgba(0,0,0,0)",
+                "textDecoration": "none",
+              },
+            },
+          },
+        }
+      }
     >
       Wow!
     </div>

--- a/src/placeholder/index.js
+++ b/src/placeholder/index.js
@@ -26,14 +26,12 @@ function _Placeholder (props) {
   const {
     classes,
     className,
-    style,
     children,
+    ...remainingProps,
   } = props;
 
   return (
-    <div className={classNames(className, classes.shimmer)}
-         style={style}
-    >
+    <div {...remainingProps} className={classNames(className, classes.shimmer)}>
       {children}
     </div>
   );

--- a/src/section/__snapshots__/Section.test.js.snap
+++ b/src/section/__snapshots__/Section.test.js.snap
@@ -248,9 +248,247 @@ exports[`Section should render as snapshot defines 1`] = `
       }
     }
   >
-    <div
+    <section
       className="wrapper-0-0"
-      style={undefined}
+      sheet={
+        StyleSheet {
+          "0.42": null,
+          "attached": true,
+          "classes": Object {
+            "wrapper": "wrapper-0-0",
+          },
+          "deployed": true,
+          "linked": false,
+          "options": Object {
+            "Renderer": [Function],
+            "classes": Object {
+              "wrapper": "wrapper-0-0",
+            },
+            "generateClassName": [Function],
+            "index": -99999,
+            "insertionPoint": undefined,
+            "jss": Jss {
+              "generateClassName": [Function],
+              "options": Object {
+                "Renderer": [Function],
+                "createGenerateClassName": [Function],
+                "plugins": Array [
+                  Object {
+                    "onCreateRule": [Function],
+                    "onProcessRule": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onChangeValue": [Function],
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onChangeValue": [Function],
+                    "onProcessRule": [Function],
+                    "onProcessStyle": [Function],
+                  },
+                  Object {
+                    "onProcessStyle": [Function],
+                  },
+                ],
+              },
+              "plugins": PluginsRegistry {
+                "hooks": Object {
+                  "onChangeValue": Array [
+                    [Function],
+                    [Function],
+                  ],
+                  "onCreateRule": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                  "onProcessRule": Array [
+                    [Function],
+                    [Function],
+                  ],
+                  "onProcessSheet": Array [],
+                  "onProcessStyle": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+              },
+              "version": "8.1.0",
+            },
+            "meta": "Jss(_Section), Unthemed, Static",
+            "parent": [Circular],
+            "sheet": [Circular],
+          },
+          "renderer": DomRenderer {
+            "element": <style
+              data-jss=""
+              data-meta="Jss(_Section), Unthemed, Static"
+              type="text/css"
+            >
+              
+.wrapper-0-0 {
+  width: 100%;
+  padding-bottom: 3em;
+  background-color: #FBFCFC;
+}
+
+            </style>,
+            "getSelector": [Function],
+            "getStyle": [Function],
+            "hasInsertedRules": false,
+            "setSelector": [Function],
+            "setStyle": [Function],
+            "sheet": [Circular],
+          },
+          "rules": RuleList {
+            "classes": Object {
+              "wrapper": "wrapper-0-0",
+            },
+            "index": Array [
+              Object {
+                "background-color": "#FBFCFC",
+                "padding-bottom": "3em",
+                "width": "100%",
+              },
+            ],
+            "map": Object {
+              ".wrapper-0-0": Object {
+                "background-color": "#FBFCFC",
+                "padding-bottom": "3em",
+                "width": "100%",
+              },
+              "wrapper": Object {
+                "background-color": "#FBFCFC",
+                "padding-bottom": "3em",
+                "width": "100%",
+              },
+            },
+            "options": Object {
+              "Renderer": [Function],
+              "classes": Object {
+                "wrapper": "wrapper-0-0",
+              },
+              "generateClassName": [Function],
+              "index": -99999,
+              "insertionPoint": undefined,
+              "jss": Jss {
+                "generateClassName": [Function],
+                "options": Object {
+                  "Renderer": [Function],
+                  "createGenerateClassName": [Function],
+                  "plugins": Array [
+                    Object {
+                      "onCreateRule": [Function],
+                      "onProcessRule": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onChangeValue": [Function],
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onChangeValue": [Function],
+                      "onProcessRule": [Function],
+                      "onProcessStyle": [Function],
+                    },
+                    Object {
+                      "onProcessStyle": [Function],
+                    },
+                  ],
+                },
+                "plugins": PluginsRegistry {
+                  "hooks": Object {
+                    "onChangeValue": Array [
+                      [Function],
+                      [Function],
+                    ],
+                    "onCreateRule": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                    "onProcessRule": Array [
+                      [Function],
+                      [Function],
+                    ],
+                    "onProcessSheet": Array [],
+                    "onProcessStyle": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                },
+                "version": "8.1.0",
+              },
+              "meta": "Jss(_Section), Unthemed, Static",
+              "parent": [Circular],
+              "sheet": [Circular],
+            },
+            "raw": Object {
+              "wrapper": Object {
+                "backgroundColor": "#FBFCFC",
+                "paddingBottom": "3em",
+                "width": "100%",
+              },
+            },
+          },
+        }
+      }
     >
       <Jss(_ContentContainer)>
         <_ContentContainer
@@ -496,10 +734,244 @@ exports[`Section should render as snapshot defines 1`] = `
         >
           <div
             className="app-0-1"
+            sheet={
+              StyleSheet {
+                "0.42": null,
+                "attached": true,
+                "classes": Object {
+                  "app": "app-0-1",
+                },
+                "deployed": true,
+                "linked": false,
+                "options": Object {
+                  "Renderer": [Function],
+                  "classes": Object {
+                    "app": "app-0-1",
+                  },
+                  "generateClassName": [Function],
+                  "index": -100000,
+                  "insertionPoint": undefined,
+                  "jss": Jss {
+                    "generateClassName": [Function],
+                    "options": Object {
+                      "Renderer": [Function],
+                      "createGenerateClassName": [Function],
+                      "plugins": Array [
+                        Object {
+                          "onCreateRule": [Function],
+                          "onProcessRule": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onChangeValue": [Function],
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onChangeValue": [Function],
+                          "onProcessRule": [Function],
+                          "onProcessStyle": [Function],
+                        },
+                        Object {
+                          "onProcessStyle": [Function],
+                        },
+                      ],
+                    },
+                    "plugins": PluginsRegistry {
+                      "hooks": Object {
+                        "onChangeValue": Array [
+                          [Function],
+                          [Function],
+                        ],
+                        "onCreateRule": Array [
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                        ],
+                        "onProcessRule": Array [
+                          [Function],
+                          [Function],
+                        ],
+                        "onProcessSheet": Array [],
+                        "onProcessStyle": Array [
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                        ],
+                      },
+                    },
+                    "version": "8.1.0",
+                  },
+                  "meta": "Jss(_ContentContainer), Unthemed, Static",
+                  "parent": [Circular],
+                  "sheet": [Circular],
+                },
+                "renderer": DomRenderer {
+                  "element": <style
+                    data-jss=""
+                    data-meta="Jss(_ContentContainer), Unthemed, Static"
+                    type="text/css"
+                  >
+                    
+.app-0-1 {
+  margin: auto;
+  max-width: 1200px;
+}
+
+                  </style>,
+                  "getSelector": [Function],
+                  "getStyle": [Function],
+                  "hasInsertedRules": false,
+                  "setSelector": [Function],
+                  "setStyle": [Function],
+                  "sheet": [Circular],
+                },
+                "rules": RuleList {
+                  "classes": Object {
+                    "app": "app-0-1",
+                  },
+                  "index": Array [
+                    Object {
+                      "margin": "auto",
+                      "max-width": "1200px",
+                    },
+                  ],
+                  "map": Object {
+                    ".app-0-1": Object {
+                      "margin": "auto",
+                      "max-width": "1200px",
+                    },
+                    "app": Object {
+                      "margin": "auto",
+                      "max-width": "1200px",
+                    },
+                  },
+                  "options": Object {
+                    "Renderer": [Function],
+                    "classes": Object {
+                      "app": "app-0-1",
+                    },
+                    "generateClassName": [Function],
+                    "index": -100000,
+                    "insertionPoint": undefined,
+                    "jss": Jss {
+                      "generateClassName": [Function],
+                      "options": Object {
+                        "Renderer": [Function],
+                        "createGenerateClassName": [Function],
+                        "plugins": Array [
+                          Object {
+                            "onCreateRule": [Function],
+                            "onProcessRule": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onChangeValue": [Function],
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onChangeValue": [Function],
+                            "onProcessRule": [Function],
+                            "onProcessStyle": [Function],
+                          },
+                          Object {
+                            "onProcessStyle": [Function],
+                          },
+                        ],
+                      },
+                      "plugins": PluginsRegistry {
+                        "hooks": Object {
+                          "onChangeValue": Array [
+                            [Function],
+                            [Function],
+                          ],
+                          "onCreateRule": Array [
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                          ],
+                          "onProcessRule": Array [
+                            [Function],
+                            [Function],
+                          ],
+                          "onProcessSheet": Array [],
+                          "onProcessStyle": Array [
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                          ],
+                        },
+                      },
+                      "version": "8.1.0",
+                    },
+                    "meta": "Jss(_ContentContainer), Unthemed, Static",
+                    "parent": [Circular],
+                    "sheet": [Circular],
+                  },
+                  "raw": Object {
+                    "app": Object {
+                      "margin": "auto",
+                      "maxWidth": "1200px",
+                    },
+                  },
+                },
+              }
+            }
           />
         </_ContentContainer>
       </Jss(_ContentContainer)>
-    </div>
+    </section>
   </_Section>
 </Jss(_Section)>
 `;

--- a/src/section/index.js
+++ b/src/section/index.js
@@ -19,16 +19,15 @@ function _Section (props) {
     classes,
     className,
     children,
-    style,
     ...remainingProps
   } = props;
 
   return (
-    <div className={classNames(classes.wrapper, className)} style={style}>
+    <section {...remainingProps} className={classNames(classes.wrapper, className)}>
       <ContentContainer>
         {children}
       </ContentContainer>
-    </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
Remove style props and instead, allow components to pass through any remaining props.

Useful if you need to add other props such as `id` and whatnot.